### PR TITLE
fix: Last Items in List are Behind The Bottom Navigation UI

### DIFF
--- a/app/src/main/java/com/kino/app/features/home/Navigation.kt
+++ b/app/src/main/java/com/kino/app/features/home/Navigation.kt
@@ -38,7 +38,9 @@ fun NavigationControl(navItems: List<NavigationRoute>) {
             }
         )
     }) {
-        Box(modifier = Modifier.fillMaxSize()) {
+        Box(modifier = Modifier
+            .fillMaxSize()
+            .padding(bottom = 45.dp)) {
             Navigation(navController = navController)
         }
 

--- a/app/src/main/java/com/kino/app/features/home/detail/DetailsScreen.kt
+++ b/app/src/main/java/com/kino/app/features/home/detail/DetailsScreen.kt
@@ -56,8 +56,7 @@ fun DetailScreen(
         }
 
         Box(modifier = Modifier
-            .fillMaxSize()
-            .padding(bottom = 45.dp)) {
+            .fillMaxSize()) {
 
             MovieContent(state.movie)
 

--- a/app/src/main/java/com/kino/app/features/home/explore/ExplorerScreen.kt
+++ b/app/src/main/java/com/kino/app/features/home/explore/ExplorerScreen.kt
@@ -26,7 +26,7 @@ fun ExplorerScreen(
 ) {
     val state = viewModel.state
 
-    Column {
+    Column(modifier = Modifier.padding(bottom = 10.dp)) {
         Text(
             modifier = Modifier
                 .fillMaxWidth()

--- a/app/src/main/java/com/kino/app/features/home/explore/components/MovieCard.kt
+++ b/app/src/main/java/com/kino/app/features/home/explore/components/MovieCard.kt
@@ -35,7 +35,7 @@ fun MovieCard(
 
     Box(modifier = Modifier
         .fillMaxWidth()
-        .padding(start = 10.dp, top = 10.dp, end = 10.dp)
+        .padding(start = 10.dp, top = 5.dp, end = 10.dp, bottom = 5.dp)
         .clickable { onSelect() },
     ) {
 

--- a/app/src/main/java/com/kino/app/features/home/favorite/FavoriteScreen.kt
+++ b/app/src/main/java/com/kino/app/features/home/favorite/FavoriteScreen.kt
@@ -43,7 +43,7 @@ fun LikedScreen(
     if (dou.isNotEmpty())
         group += dou
 
-    Column {
+    Column(modifier = Modifier.padding(bottom = 10.dp)) {
         Text(
             modifier = Modifier
                 .fillMaxWidth()


### PR DESCRIPTION
The last movie items in Explorer and Favorite Screens are not properly displayed because partially covered by the navigation bar UI